### PR TITLE
Typo fix content.opf: series Waverly > ~ley

### DIFF
--- a/src/epub/content.opf
+++ b/src/epub/content.opf
@@ -64,7 +64,7 @@
 		<meta property="term" refines="#subject-9">Unknown</meta>
 		<meta property="se:subject">Adventure</meta>
 		<meta property="se:subject">Fiction</meta>
-		<meta id="collection-1" property="belongs-to-collection">Waverly</meta>
+		<meta id="collection-1" property="belongs-to-collection">Waverley</meta>
 		<meta property="collection-type" refines="#collection-1">series</meta>
 		<meta property="group-position" refines="#collection-1">10</meta>
 		<dc:description id="description">A disinherited knight returns from the Crusades and fights back against Prince John’s reign.</dc:description>


### PR DESCRIPTION
Noticed this with the new "Collections" page on the SE website.